### PR TITLE
Add Apostrophe to Tool Description

### DIFF
--- a/server/openapi_server/controllers/tool_controller.py
+++ b/server/openapi_server/controllers/tool_controller.py
@@ -16,7 +16,7 @@ def get_tool():  # noqa: E501
         version="0.1.6",
         license=License.APACHE_2_0,
         repository="github:cascadianblue/person-name-annotator",
-        description="Connor Boyle",
+        description="Connor Boyle'",
         author="Connor Boyle",
         author_email="connorbo@gmail.com",
         url="https://github.com/cascadianblue/person-name-annotator",


### PR DESCRIPTION
This will probably trip up the workflow orchestrator